### PR TITLE
Add user-based highlights and history data

### DIFF
--- a/llm_review_project/editor/migrations/0003_inferenceresult_add_fields.py
+++ b/llm_review_project/editor/migrations/0003_inferenceresult_add_fields.py
@@ -1,0 +1,34 @@
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('editor', '0002_inferenceresult_parsed_result_and_more'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='inferenceresult',
+            name='patient_id',
+            field=models.CharField(blank=True, max_length=100, verbose_name='환자ID'),
+        ),
+        migrations.AddField(
+            model_name='inferenceresult',
+            name='solution_name',
+            field=models.CharField(blank=True, max_length=100, verbose_name='솔루션 이름'),
+        ),
+        migrations.AddField(
+            model_name='inferenceresult',
+            name='last_modified_by',
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name='modified_results',
+                to=settings.AUTH_USER_MODEL,
+                verbose_name='마지막 수정자',
+            ),
+        ),
+    ]

--- a/llm_review_project/editor/models.py
+++ b/llm_review_project/editor/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.utils import timezone
+from django.conf import settings
 
 class InferenceResult(models.Model):
     prompt = models.TextField("프롬프트 요약")
@@ -7,6 +8,16 @@ class InferenceResult(models.Model):
     edited_text = models.TextField("수정된 텍스트 (Raw Text)", blank=True)
     # 파싱된 JSON 결과를 저장할 필드 추가
     parsed_result = models.JSONField("파싱된/수정된 결과", null=True, blank=True)
+    patient_id = models.CharField("환자ID", max_length=100, blank=True)
+    solution_name = models.CharField("솔루션 이름", max_length=100, blank=True)
+    last_modified_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        verbose_name="마지막 수정자",
+        related_name="modified_results",
+    )
     created_at = models.DateTimeField("생성 시각", default=timezone.now)
 
     def __str__(self):

--- a/llm_review_project/editor/templates/editor/main_editor.html
+++ b/llm_review_project/editor/templates/editor/main_editor.html
@@ -82,7 +82,13 @@
                 {% csrf_token %}
                 <div class="mb-4">
                     <h2 class="text-xl font-bold text-slate-800">결과 보기 및 수정 (ID: {{ current_result.id }})</h2>
-                    <p class="text-sm text-slate-500 mt-1"><strong>입력 요약:</strong> {{ current_result.prompt|truncatewords:20 }}</p>
+                    <p class="text-sm text-slate-500 mt-1">
+                        <strong>환자 ID:</strong> {{ current_result.patient_id }}
+                        <strong class="ml-4">솔루션:</strong> {{ current_result.solution_name }}
+                        {% if current_result.last_modified_by %}
+                        <span class="ml-4"><strong>수정자:</strong> {{ current_result.last_modified_by.username }}</span>
+                        {% endif %}
+                    </p>
                 </div>
                 
                 {% if current_result.images.all %}
@@ -166,8 +172,13 @@
             {% for result in all_results %}
             <a href="{% url 'editor:editor_with_id' result.id %}" class="block">
                 <li class="p-4 border-b hover:bg-slate-50 {% if current_result.id == result.id %}bg-blue-100{% endif %}">
-                    <p class="font-semibold text-slate-700 truncate">{{ result.prompt|truncatewords:10 }}</p>
-                    <p class="text-sm text-slate-500">{{ result.created_at|date:"Y.m.d H:i" }}</p>
+                    <p class="font-semibold text-slate-700 truncate">{{ result.patient_id }} - {{ result.solution_name }}</p>
+                    <p class="text-sm text-slate-500">
+                        {{ result.created_at|date:"Y.m.d H:i" }}
+                        {% if result.last_modified_by %}
+                            · {{ result.last_modified_by.username }}
+                        {% endif %}
+                    </p>
                 </li>
             </a>
             {% empty %}
@@ -201,15 +212,16 @@
         });
         solutionSelect.dispatchEvent(new Event('change'));
 
-        // 수정된 필드 빨간색으로 표시하는 로직
+        // 수정된 필드 색상 표시 로직
+        const userColor = "{{ user_color }}";
         const editableFields = document.querySelectorAll('.editable-field');
         editableFields.forEach(field => {
             field.dataset.originalValue = field.value;
             field.addEventListener('input', function() {
                 if (this.value !== this.dataset.originalValue) {
-                    this.classList.add('text-red-600', 'font-semibold');
+                    this.classList.add(userColor, 'font-semibold');
                 } else {
-                    this.classList.remove('text-red-600', 'font-semibold');
+                    this.classList.remove(userColor, 'font-semibold');
                 }
             });
         });

--- a/llm_review_project/editor/templatetags/diff_tags.py
+++ b/llm_review_project/editor/templatetags/diff_tags.py
@@ -1,0 +1,23 @@
+from django import template
+from django.utils.safestring import mark_safe
+import difflib
+
+register = template.Library()
+
+@register.filter
+def diff_highlight(new_text, old_text):
+    """Return HTML diff showing additions in <span> tags."""
+    if not old_text:
+        return new_text
+    diff = difflib.ndiff(old_text.split(), new_text.split())
+    result = []
+    for part in diff:
+        code = part[:2]
+        text = part[2:]
+        if code == '+ ':
+            result.append(f'<span class="diff-added">{text}</span>')
+        elif code == '- ':
+            continue
+        else:
+            result.append(text)
+    return mark_safe(' '.join(result))

--- a/llm_review_project/editor/views.py
+++ b/llm_review_project/editor/views.py
@@ -4,6 +4,17 @@ from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth.decorators import login_required
 from .models import InferenceResult, InferenceImage
 
+USER_COLORS = [
+    "text-red-600",
+    "text-blue-600",
+    "text-green-600",
+    "text-purple-600",
+    "text-orange-600",
+]
+
+def get_user_color(username: str) -> str:
+    return USER_COLORS[hash(username) % len(USER_COLORS)]
+
 
 
 VLLM_API_URL = "http://localhost:8001/v1/completions" 
@@ -132,7 +143,8 @@ def main_editor_view(request, result_id=None):
     context = {
         'all_results': all_results,
         'current_result': current_result,
-        'solutions_data': SOLUTIONS_DATA, 
+        'solutions_data': SOLUTIONS_DATA,
+        'user_color': get_user_color(request.user.username),
     }
     return render(request, 'editor/main_editor.html', context)
 
@@ -195,7 +207,10 @@ def create_inference(request):
                 prompt=db_prompt,
                 original_text=generated_text,
                 edited_text=generated_text,
-                parsed_result=parsed_data
+                parsed_result=parsed_data,
+                patient_id=request.POST.get('patient_id', ''),
+                solution_name=solution_name,
+                last_modified_by=request.user,
             )
 
             for uploaded_file in request.FILES.getlist('images'):
@@ -228,6 +243,8 @@ def save_edit(request, result_id):
             }
             result.parsed_result = clean_json_keys(updated_data)
             result.edited_text = json.dumps(updated_data, ensure_ascii=False, indent=2)
+            result.patient_id = request.POST.get("환자ID", result.patient_id)
+            result.last_modified_by = request.user
             result.save()
         except (ValueError, TypeError) as e:
             print(f"Error reconstructing JSON: {e}")


### PR DESCRIPTION
## Summary
- track patient, solution, and last modified user in `InferenceResult`
- migration for the new model fields
- show patient and solution in the editor header and history panel
- color edited fields per user using a unique color
- utility template tags for future diff highlighting

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686c7ceabd388322aa0a8e12d505197a