### PR TITLE
Add diff view for edited results

### DIFF
--- a/llm_review_project/editor/migrations/0003_inferenceresult_add_fields.py
+++ b/llm_review_project/editor/migrations/0003_inferenceresult_add_fields.py
@@ -1,0 +1,34 @@
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('editor', '0002_inferenceresult_parsed_result_and_more'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='inferenceresult',
+            name='patient_id',
+            field=models.CharField(blank=True, max_length=100, verbose_name='환자ID'),
+        ),
+        migrations.AddField(
+            model_name='inferenceresult',
+            name='solution_name',
+            field=models.CharField(blank=True, max_length=100, verbose_name='솔루션 이름'),
+        ),
+        migrations.AddField(
+            model_name='inferenceresult',
+            name='last_modified_by',
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name='modified_results',
+                to=settings.AUTH_USER_MODEL,
+                verbose_name='마지막 수정자',
+            ),
+        ),
+    ]

--- a/llm_review_project/editor/models.py
+++ b/llm_review_project/editor/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.utils import timezone
+from django.conf import settings
 
 class InferenceResult(models.Model):
     prompt = models.TextField("프롬프트 요약")
@@ -7,6 +8,16 @@ class InferenceResult(models.Model):
     edited_text = models.TextField("수정된 텍스트 (Raw Text)", blank=True)
     # 파싱된 JSON 결과를 저장할 필드 추가
     parsed_result = models.JSONField("파싱된/수정된 결과", null=True, blank=True)
+    patient_id = models.CharField("환자ID", max_length=100, blank=True)
+    solution_name = models.CharField("솔루션 이름", max_length=100, blank=True)
+    last_modified_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        verbose_name="마지막 수정자",
+        related_name="modified_results",
+    )
     created_at = models.DateTimeField("생성 시각", default=timezone.now)
 
     def __str__(self):

--- a/llm_review_project/editor/templates/editor/main_editor.html
+++ b/llm_review_project/editor/templates/editor/main_editor.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="ko">
+{% load diff_tags %}
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -9,6 +10,7 @@
         #image-modal { transition: opacity 0.3s ease-in-out; }
         #modal-image { transition: transform 0.3s ease-in-out; transform: scale(0.95); }
         #image-modal.visible #modal-image { transform: scale(1); }
+        .diff-added { font-weight: bold; }
     </style>
 </head>
 <body class="bg-slate-100">
@@ -82,7 +84,18 @@
                 {% csrf_token %}
                 <div class="mb-4">
                     <h2 class="text-xl font-bold text-slate-800">결과 보기 및 수정 (ID: {{ current_result.id }})</h2>
-                    <p class="text-sm text-slate-500 mt-1"><strong>입력 요약:</strong> {{ current_result.prompt|truncatewords:20 }}</p>
+                    <p class="text-sm text-slate-500 mt-1">
+                        <strong>환자 ID:</strong> {{ current_result.patient_id }}
+                        <strong class="ml-4">솔루션:</strong> {{ current_result.solution_name }}
+                        {% if current_result.last_modified_by %}
+                            <span class="ml-4"><strong>수정자:</strong> <span class="{{ current_result.user_color }}">{{ current_result.last_modified_by.username }}</span></span>
+                        {% endif %}
+                    </p>
+                    {% if current_result.edited_text != current_result.original_text %}
+                    <div class="mt-2 p-2 bg-slate-50 rounded">
+                        <pre class="whitespace-pre-wrap text-sm">{% diff_highlight current_result.edited_text current_result.original_text current_result.user_color %}</pre>
+                    </div>
+                    {% endif %}
                 </div>
                 
                 {% if current_result.images.all %}
@@ -166,8 +179,13 @@
             {% for result in all_results %}
             <a href="{% url 'editor:editor_with_id' result.id %}" class="block">
                 <li class="p-4 border-b hover:bg-slate-50 {% if current_result.id == result.id %}bg-blue-100{% endif %}">
-                    <p class="font-semibold text-slate-700 truncate">{{ result.prompt|truncatewords:10 }}</p>
-                    <p class="text-sm text-slate-500">{{ result.created_at|date:"Y.m.d H:i" }}</p>
+                    <p class="font-semibold text-slate-700 truncate">{{ result.patient_id }} - {{ result.solution_name }}</p>
+                    <p class="text-sm text-slate-500">
+                        {{ result.created_at|date:"Y.m.d H:i" }}
+                        {% if result.last_modified_by %}
+                            · <span class="{{ result.user_color }}">{{ result.last_modified_by.username }}</span>
+                        {% endif %}
+                    </p>
                 </li>
             </a>
             {% empty %}
@@ -201,18 +219,6 @@
         });
         solutionSelect.dispatchEvent(new Event('change'));
 
-        // 수정된 필드 빨간색으로 표시하는 로직
-        const editableFields = document.querySelectorAll('.editable-field');
-        editableFields.forEach(field => {
-            field.dataset.originalValue = field.value;
-            field.addEventListener('input', function() {
-                if (this.value !== this.dataset.originalValue) {
-                    this.classList.add('text-red-600', 'font-semibold');
-                } else {
-                    this.classList.remove('text-red-600', 'font-semibold');
-                }
-            });
-        });
         
         // 이미지 확대/축소 로직
         const modal = document.getElementById('image-modal');

--- a/llm_review_project/editor/templatetags/diff_tags.py
+++ b/llm_review_project/editor/templatetags/diff_tags.py
@@ -1,0 +1,25 @@
+from django import template
+from django.utils.safestring import mark_safe
+import difflib
+
+register = template.Library()
+
+@register.simple_tag
+def diff_highlight(new_text, old_text='', color_class='text-red-600'):
+    """Return HTML diff highlighting additions with the given color."""
+    if not old_text:
+        return mark_safe(new_text)
+
+    diff = difflib.ndiff(old_text.split(), new_text.split())
+    pieces = []
+    for part in diff:
+        code = part[:2]
+        text = part[2:]
+        if code == '+ ':
+            pieces.append(f'<span class="{color_class} diff-added">{text}</span>')
+        elif code == '- ':
+            continue
+        else:
+            pieces.append(text)
+
+    return mark_safe(' '.join(pieces))


### PR DESCRIPTION
## Summary
- show diff between original and edited text with color highlighting
- remove live field highlighting logic
- color usernames in history list
- expose user color in templates from view

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686c7ceabd388322aa0a8e12d505197a