### PR TITLE
Fix diff highlight tag in editor

### DIFF
--- a/llm_review_project/editor/templatetags/diff_tags.py
+++ b/llm_review_project/editor/templatetags/diff_tags.py
@@ -4,7 +4,6 @@ import difflib
 
 register = template.Library()
 
-
 @register.simple_tag
 def diff_highlight(new_text, old_text='', color_class='text-red-600'):
     """Return HTML diff highlighting additions with the given color."""
@@ -13,39 +12,13 @@ def diff_highlight(new_text, old_text='', color_class='text-red-600'):
 
     diff = difflib.ndiff(old_text.split(), new_text.split())
     pieces = []
-
-@register.filter
-def diff_highlight(new_text, old_text):
-    """Return HTML diff showing additions in <span> tags."""
-    if not old_text:
-        return new_text
-    diff = difflib.ndiff(old_text.split(), new_text.split())
-    result = []
-
     for part in diff:
         code = part[:2]
         text = part[2:]
         if code == '+ ':
-
             pieces.append(f'<span class="{color_class} diff-added">{text}</span>')
         elif code == '  ':
             pieces.append(text)
         # removed words are skipped
 
     return mark_safe(' '.join(pieces))
-
-            pieces.append(f'<span class="{color_class} diff-added">{text}</span>')
-        elif code == '- ':
-            continue
-        else:
-            pieces.append(text)
-
-    return mark_safe(' '.join(pieces))
-
-            result.append(f'<span class="diff-added">{text}</span>')
-        elif code == '- ':
-            continue
-        else:
-            result.append(text)
-    return mark_safe(' '.join(result))
-


### PR DESCRIPTION
## Summary
- remove duplicate filter code and clean up `diff_highlight` implementation

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686c84901458832293f0ea1067083d99