### PR TITLE
Fix diff false positives

### DIFF
--- a/llm_review_project/editor/templates/editor/main_editor.html
+++ b/llm_review_project/editor/templates/editor/main_editor.html
@@ -163,7 +163,7 @@
     </div>
 
     <!-- Right Panel -->
-<div class="w-1/3 max-w-sm bg-white border-l h-full flex flex-col">
+<div class="w-1/3 max-w-sm bg-white border-l h-full flex flex-col flex-shrink-0">
         <div class="p-4 border-b flex justify-between items-center">
             <h2 class="text-xl font-bold text-slate-800">추론 기록</h2>
             <div class="flex items-center space-x-2"> {# 이 div를 추가하여 새 추론과 로그아웃 버튼을 그룹화합니다. #}
@@ -180,7 +180,7 @@
             {% for result in all_results %}
             <a href="{% url 'editor:editor_with_id' result.id %}" class="block">
                 <li class="p-4 border-b hover:bg-slate-50 {% if current_result.id == result.id %}bg-blue-100{% endif %}">
-                    <p class="font-semibold text-slate-700 truncate">{{ result.patient_id }} - {{ result.solution_name }}</p>
+                    <p class="font-semibold text-slate-700 truncate">{{ result.id }} - {{ result.solution_name }} ({{ result.patient_id }})</p>
                     <p class="text-sm text-slate-500">
                         {{ result.created_at|date:"Y.m.d H:i" }}
                         {% if result.last_modified_by %}

--- a/llm_review_project/editor/templatetags/diff_tags.py
+++ b/llm_review_project/editor/templatetags/diff_tags.py
@@ -1,13 +1,35 @@
 from django import template
 from django.utils.safestring import mark_safe
 import difflib
+import json
 
 register = template.Library()
 
 @register.simple_tag
 def diff_highlight(new_text, old_text='', color_class='text-red-600'):
-    """Return HTML diff highlighting additions with the given color."""
+    """Return HTML diff highlighting additions with the given color.
+
+    Leading/trailing or internal whitespace differences can occur when
+    converting JSON to strings. To avoid false highlights, compare the two
+    strings after removing all whitespace characters. If they match, return
+    the new text without any highlighting.
+    """
+
     if not old_text:
+        return mark_safe(new_text)
+
+    # Try JSON normalization first to avoid false positives caused by
+    # formatting differences or key ordering.
+    try:
+        new_obj = json.loads(new_text)
+        old_obj = json.loads(old_text)
+        new_normalized = json.dumps(new_obj, ensure_ascii=False, sort_keys=True)
+        old_normalized = json.dumps(old_obj, ensure_ascii=False, sort_keys=True)
+    except Exception:
+        new_normalized = ''.join(new_text.split())
+        old_normalized = ''.join(old_text.split())
+
+    if new_normalized == old_normalized:
         return mark_safe(new_text)
 
     diff = difflib.ndiff(old_text.split(), new_text.split())


### PR DESCRIPTION
## Summary
- refine whitespace handling in diff tag
- normalize JSON structures before diffing to reduce false positives

## Testing
- `python llm_review_project/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686c8839ed788322ac19fd4a549975bc