### PR TITLE
Fix escaping of closing brace in diff tags

### DIFF
--- a/llm_review_project/editor/templatetags/diff_tags.py
+++ b/llm_review_project/editor/templatetags/diff_tags.py
@@ -143,7 +143,7 @@ def _render_json(obj, colors, path="", indent=0):
             rendered = _render_json(val, colors, sub_path, indent + 2)
             comma = "," if idx < len(keys) - 1 else ""
             lines.append(f"{space}  \"{escape(key)}\": {rendered}{comma}")
-        lines.append(f"{space}}")
+        lines.append(f"{space}}}")
         return "\n".join(lines)
     elif isinstance(obj, list):
         lines = ["["]


### PR DESCRIPTION
## Summary
- escape closing curly brace in `_render_json`

## Testing
- `python manage.py runserver 0.0.0.0:8002` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686c97a6598c8322bf0c120e1b0d8150