### PR TITLE
Add manual exam time input and DICOM upload handling

### DIFF
--- a/llm_review_project/editor/templates/editor/main_editor.html
+++ b/llm_review_project/editor/templates/editor/main_editor.html
@@ -58,7 +58,7 @@
                         </div>
                         <div>
                             <label for="exam_time" class="block text-sm font-medium text-slate-600">검사 일시</label>
-                            <input type="datetime-local" name="exam_time" id="exam_time" class="mt-1 block w-full p-2 border rounded-md">
+                            <input type="text" name="exam_time" id="exam_time" placeholder="YYYY-MM-DDTHH:MM" class="mt-1 block w-full p-2 border rounded-md" />
                         </div>
                     </div>
                     <div>

--- a/llm_review_project/editor/utils.py
+++ b/llm_review_project/editor/utils.py
@@ -10,3 +10,37 @@ USER_COLORS = [
 def get_user_color(username: str) -> str:
     """Return a stable color class for the given username."""
     return USER_COLORS[hash(username) % len(USER_COLORS)]
+
+
+def dicom_to_png(uploaded_file):
+    """Convert an uploaded DICOM file to a PNG SimpleUploadedFile.
+
+    The caller is responsible for ensuring ``pydicom`` and ``Pillow`` are
+    installed. If conversion fails, ``None`` is returned.
+    """
+    try:
+        import io
+        from django.core.files.uploadedfile import SimpleUploadedFile
+        import pydicom
+        from PIL import Image
+
+        ds = pydicom.dcmread(uploaded_file)
+        pixel_array = ds.pixel_array
+
+        # normalise pixel data to 0-255
+        pixel_array = pixel_array.astype('float32')
+        pixel_array -= pixel_array.min()
+        if pixel_array.max() > 0:
+            pixel_array = pixel_array / pixel_array.max() * 255.0
+        image = Image.fromarray(pixel_array.astype('uint8'))
+
+        buf = io.BytesIO()
+        image.save(buf, format='PNG')
+        buf.seek(0)
+        return SimpleUploadedFile(
+            uploaded_file.name.rsplit('.', 1)[0] + '.png',
+            buf.read(),
+            content_type='image/png'
+        )
+    except Exception:
+        return None

--- a/llm_review_project/editor/views.py
+++ b/llm_review_project/editor/views.py
@@ -221,7 +221,22 @@ def create_inference(request):
             )
 
             for uploaded_file in request.FILES.getlist('images'):
-                InferenceImage.objects.create(inference_result=new_result, image=uploaded_file)
+                if uploaded_file.name.lower().endswith('.dcm'):
+                    from .utils import dicom_to_png
+                    png_file = dicom_to_png(uploaded_file)
+                    if png_file:
+                        InferenceImage.objects.create(
+                            inference_result=new_result,
+                            image=png_file,
+                        )
+                    else:
+                        # fallback: skip the file if conversion fails
+                        continue
+                else:
+                    InferenceImage.objects.create(
+                        inference_result=new_result,
+                        image=uploaded_file,
+                    )
 
             return redirect('editor:editor_with_id', result_id=new_result.id)
         except Exception as e:


### PR DESCRIPTION
## Summary
- allow free text entry for examination datetime
- convert uploaded DICOM files to PNG for display

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686ca59745d0832294c61eb38a7d5b65