### PR TITLE
Enable multi-delete for history list

### DIFF
--- a/llm_review_project/editor/templates/editor/main_editor.html
+++ b/llm_review_project/editor/templates/editor/main_editor.html
@@ -196,26 +196,34 @@
         </div>
 
 
-        <ul class="overflow-y-auto flex-grow">
-            {% for result in all_results %}
-            <a href="{% url 'editor:editor_with_id' result.id %}" class="block">
-                <li class="p-4 border-b hover:bg-slate-50 {% if current_result.id == result.id %}bg-blue-100{% endif %}">
-                    <p class="font-semibold text-slate-700 truncate">{{ result.id }} - {{ result.solution_name }} ({{ result.patient_id }})</p>
-                    <p class="text-sm text-slate-500">
-                        {{ result.created_at|date:"Y.m.d H:i" }}
-                        {% if result.editors %}
-                            ·
-                            {% for ed in result.editors %}
-                                <span class="{{ ed.color }}">{{ ed.name }}</span>{% if not forloop.last %}, {% endif %}
-                            {% endfor %}
-                        {% endif %}
-                    </p>
+        <form id="delete-selected-form" method="post" action="{% url 'editor:delete_selected' %}" class="flex flex-col flex-grow">
+            {% csrf_token %}
+            <div id="selected-actions" class="hidden sticky top-0 bg-white z-10 border-b p-2 flex justify-between items-center">
+                <button type="button" id="select-all" class="text-sm bg-gray-100 px-2 py-1 rounded">전체 선택</button>
+                <button type="submit" class="text-sm bg-red-600 text-white px-2 py-1 rounded">선택 삭제</button>
+            </div>
+            <ul id="history-list" class="overflow-y-auto flex-grow">
+                {% for result in all_results %}
+                <li class="relative border-b hover:bg-slate-50 {% if current_result.id == result.id %}bg-blue-100{% endif %}">
+                    <input type="checkbox" class="select-checkbox absolute left-2 top-1/2 -translate-y-1/2" name="selected_ids" value="{{ result.id }}" />
+                    <a href="{% url 'editor:editor_with_id' result.id %}" class="block pl-8 p-4 history-link">
+                        <p class="font-semibold text-slate-700 truncate">{{ result.id }} - {{ result.solution_name }} ({{ result.patient_id }})</p>
+                        <p class="text-sm text-slate-500">
+                            {{ result.created_at|date:"Y.m.d H:i" }}
+                            {% if result.editors %}
+                                ·
+                                {% for ed in result.editors %}
+                                    <span class="{{ ed.color }}">{{ ed.name }}</span>{% if not forloop.last %}, {% endif %}
+                                {% endfor %}
+                            {% endif %}
+                        </p>
+                    </a>
                 </li>
-            </a>
-            {% empty %}
-            <li class="p-4 text-center text-slate-500">기록이 없습니다.</li>
-            {% endfor %}
-        </ul>
+                {% empty %}
+                <li class="p-4 text-center text-slate-500">기록이 없습니다.</li>
+                {% endfor %}
+            </ul>
+        </form>
     </div>
 </div>
 
@@ -280,6 +288,38 @@
                 modal.classList.add('hidden');
                 modal.classList.remove('flex');
             }, 300);
+        });
+
+        // 선택 삭제 로직
+        const historyList = document.getElementById('history-list');
+        const checkboxes = document.querySelectorAll('.select-checkbox');
+        const actions = document.getElementById('selected-actions');
+        const selectAllBtn = document.getElementById('select-all');
+
+        function updateActions() {
+            const anyChecked = Array.from(checkboxes).some(cb => cb.checked);
+            actions.classList.toggle('hidden', !anyChecked);
+        }
+
+        checkboxes.forEach(cb => {
+            cb.addEventListener('click', function(e) {
+                e.stopPropagation();
+                updateActions();
+            });
+        });
+
+        selectAllBtn.addEventListener('click', function() {
+            const allChecked = Array.from(checkboxes).every(cb => cb.checked);
+            checkboxes.forEach(cb => { cb.checked = !allChecked; });
+            updateActions();
+        });
+
+        // 스크롤 위치 유지
+        historyList.scrollTop = localStorage.getItem('historyScroll') || 0;
+        document.querySelectorAll('.history-link').forEach(link => {
+            link.addEventListener('click', function() {
+                localStorage.setItem('historyScroll', historyList.scrollTop);
+            });
         });
 
         // 자동 엑셀 업로드

--- a/llm_review_project/editor/urls.py
+++ b/llm_review_project/editor/urls.py
@@ -9,5 +9,6 @@ urlpatterns = [
     path('create/', views.create_inference, name='create_inference'),
     path('result/<int:result_id>/save/', views.save_edit, name='save_edit'),
     path('result/<int:result_id>/delete/', views.delete_result, name='delete_result'),
+    path('delete_selected/', views.delete_selected, name='delete_selected'),
     path('upload_excel/', views.upload_excel, name='upload_excel'),
 ]

--- a/llm_review_project/editor/views.py
+++ b/llm_review_project/editor/views.py
@@ -116,6 +116,15 @@ def delete_result(request, result_id):
 
 
 @login_required
+def delete_selected(request):
+    if request.method == 'POST':
+        ids = request.POST.getlist('selected_ids')
+        if ids:
+            InferenceResult.objects.filter(id__in=ids).delete()
+    return redirect('editor:main_editor')
+
+
+@login_required
 def upload_excel(request):
     """Handle Excel uploads for batch inference sequentially."""
     if request.method == 'POST' and request.FILES.get('excel_file'):


### PR DESCRIPTION
## Summary
- allow selecting results from the history sidebar
- provide select-all and delete controls
- keep sidebar scroll position when opening a result
- add view and URL to delete multiple results

## Testing
- `python llm_review_project/manage.py check` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686dd089b1e48322b10078f2a7325042