### PR TITLE
Add requirements file and installation notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# jllm
+
+This repository contains a Django project.
+
+## Installation
+
+Install the required packages (Django, pandas, numpy, Pillow, pydicom, requests, etc.):
+
+```bash
+pip install -r requirements.txt
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+Django
+pandas
+numpy
+Pillow
+pydicom
+requests
+openpyxl


### PR DESCRIPTION
## Summary
- add Python packages used in requirements.txt
- document `pip install -r requirements.txt` in README

## Testing
- `python llm_review_project/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Django)*

------
https://chatgpt.com/codex/tasks/task_e_686e0328eb248322bfac002d84b60948