### PR TITLE
Fix diff_tags user color reference

### DIFF
--- a/llm_review_project/editor/templatetags/diff_tags.py
+++ b/llm_review_project/editor/templatetags/diff_tags.py
@@ -14,11 +14,6 @@ USER_COLORS = [
 from ..utils import get_user_color
 
 
-def get_user_color(username: str) -> str:
-    """Return a stable color class for the given username."""
-    return USER_COLORS[hash(username) % len(USER_COLORS)]
-
-
 register = template.Library()
 
 @register.simple_tag


### PR DESCRIPTION
## Summary
- remove local `get_user_color` helper in `diff_tags`
- rely on the shared implementation from `utils.py`

## Testing
- `python manage.py test` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686e032ad7b483229d4b40f6421aea6f