### PR TITLE
Add unit tests for inference flow

### DIFF
--- a/llm_review_project/editor/tests.py
+++ b/llm_review_project/editor/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/llm_review_project/editor/tests/test_create_inference_view.py
+++ b/llm_review_project/editor/tests/test_create_inference_view.py
@@ -1,0 +1,41 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+from unittest.mock import patch, MagicMock
+
+from editor.models import InferenceResult
+
+
+class CreateInferenceViewTests(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            username="tester", password="pw"
+        )
+
+    @patch("editor.views.perform_inference")
+    def test_create_inference_success(self, mock_perform):
+        self.client.force_login(self.user)
+        result = InferenceResult.objects.create(
+            prompt="p", original_text="o", edited_text="o"
+        )
+        mock_perform.return_value = result
+
+        response = self.client.post(
+            reverse("editor:create_inference"),
+            {"solution": "default", "prompt": "hello"},
+        )
+        self.assertRedirects(
+            response,
+            reverse("editor:editor_with_id", args=[result.id]),
+        )
+        mock_perform.assert_called_once()
+
+    @patch("editor.views.perform_inference")
+    def test_create_inference_failure(self, mock_perform):
+        self.client.force_login(self.user)
+        mock_perform.return_value = None
+        response = self.client.post(
+            reverse("editor:create_inference"),
+            {"solution": "default", "prompt": "hello"},
+        )
+        self.assertRedirects(response, reverse("editor:main_editor"))

--- a/llm_review_project/editor/tests/test_diff_tags.py
+++ b/llm_review_project/editor/tests/test_diff_tags.py
@@ -1,0 +1,44 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from editor.templatetags import diff_tags
+from editor.models import InferenceResult, EditHistory
+
+
+class DiffTagTests(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            username="tester", password="pw"
+        )
+        self.other = get_user_model().objects.create_user(
+            username="other", password="pw"
+        )
+
+    def test_diff_highlight_and_json_equal(self):
+        text1 = '{"a":1, "b":2}'
+        text2 = '{"b":2, "a":1}'
+        # identical after normalization
+        self.assertEqual(diff_tags.diff_highlight(text1, text2), text1)
+        self.assertTrue(diff_tags.json_equal(text1, text2))
+        changed = diff_tags.diff_highlight("foo bar", "foo")
+        self.assertIn("<span", changed)
+
+    def test_json_history_diff(self):
+        result = InferenceResult.objects.create(
+            prompt="p",
+            original_text="orig",
+            edited_text="orig",
+            parsed_result={"val": "one"},
+            last_modified_by=self.user,
+        )
+        EditHistory.objects.create(result=result, editor=self.user, edited_data={"val": "one"})
+        EditHistory.objects.create(result=result, editor=self.other, edited_data={"val": "two"})
+        html = diff_tags.json_history_diff(result)
+        self.assertIn("two", html)
+        self.assertIn("diff-added", html)
+
+    def test_json_history_diff_no_history(self):
+        result = InferenceResult.objects.create(
+            prompt="p", original_text="text", edited_text="text"
+        )
+        html = diff_tags.json_history_diff(result)
+        self.assertEqual(html, result.edited_text)

--- a/llm_review_project/editor/tests/test_perform_inference.py
+++ b/llm_review_project/editor/tests/test_perform_inference.py
@@ -1,0 +1,32 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from unittest.mock import patch, MagicMock
+
+from editor.utils import perform_inference
+from editor.models import InferenceResult
+
+
+class PerformInferenceTests(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            username="tester", password="pw"
+        )
+
+    @patch("editor.utils.requests.post")
+    def test_perform_inference_success(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"choices": [{"text": '{"foo": "bar"}'}]}
+        mock_resp.raise_for_status.return_value = None
+        mock_post.return_value = mock_resp
+
+        result = perform_inference(self.user, "default", ai_json="{}")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.parsed_result, {"foo": "bar"})
+        self.assertEqual(result.last_modified_by, self.user)
+        self.assertEqual(result.history.count(), 1)
+
+    @patch("editor.utils.requests.post")
+    def test_perform_inference_no_prompt(self, mock_post):
+        result = perform_inference(self.user, "default", ai_json="")
+        self.assertIsNone(result)
+        mock_post.assert_not_called()


### PR DESCRIPTION
## Summary
- add unit tests for `perform_inference`
- test `create_inference` view behaviour
- cover template tag helpers
- remove old empty tests module

## Testing
- `python llm_review_project/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686e032c5bec832280faf866b262ef10