### PR TITLE
Improve json parsing with fallback extraction

### DIFF
--- a/llm_review_project/editor/tests/test_utils.py
+++ b/llm_review_project/editor/tests/test_utils.py
@@ -1,0 +1,12 @@
+from django.test import TestCase
+
+from editor.utils import parse_json_from_string
+
+
+class ParseJsonFallbackTests(TestCase):
+    def test_parse_key_value_fallback(self):
+        text = "환자ID: 123\n성별: 남자\n나이: 45"
+        result = parse_json_from_string(text)
+        self.assertEqual(result["환자ID"], "123")
+        self.assertEqual(result["성별"], "남자")
+        self.assertEqual(result["나이"], 45)


### PR DESCRIPTION
## Summary
- fallback parse with predefined keys when JSON decode fails
- add tests for fallback parsing

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686e1cec13c48322aa27802fd891ac95