### PR TITLE
Improve JSON parsing with fenced block fallback

### DIFF
--- a/llm_review_project/editor/tests/test_utils.py
+++ b/llm_review_project/editor/tests/test_utils.py
@@ -10,3 +10,15 @@ class ParseJsonFallbackTests(TestCase):
         self.assertEqual(result["환자ID"], "123")
         self.assertEqual(result["성별"], "남자")
         self.assertEqual(result["나이"], 45)
+
+
+class ParseJsonBlockTests(TestCase):
+    def test_extract_fenced_json(self):
+        text = "prefix\n```json\n{\"a\": 1}\n```\nsuffix"
+        result = parse_json_from_string(text)
+        self.assertEqual(result["a"], 1)
+
+    def test_invalid_fenced_json_fix(self):
+        text = "```json\n{'a':1,}\n```"
+        result = parse_json_from_string(text)
+        self.assertEqual(result["a"], 1)


### PR DESCRIPTION
## Summary
- add `_extract_json_block` helper and fallback parsing inside code fences
- extend tests for fenced JSON blocks and invalid JSON recovery

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686e2d39586883228cc85ccd0cc50aa2